### PR TITLE
Fix #4 : Use the correct name for calling build on projects

### DIFF
--- a/build-all
+++ b/build-all
@@ -3,7 +3,7 @@
 # Notice that the order matters, due to build dependencies"
 
 
-MSVC_PKGS="edison-core-types edison-grove-airquality edison-grove-luminosity edison-grove-temperature edison-lcd edison-led edison-smartled"
+MSVC_PKGS="edison-core-types edison-grove-airquality edison-grove-luminosity edison-grove-temperature edison-grove-lcd edison-grove-led edison-smartled"
 
 
 for svc in ${MSVC_PKGS}


### PR DESCRIPTION
- Replace edison-led edison-grove-led
- Replace edison-lcd edison-grove-lcd

Signed-off-by: Benoit Maggi benoit.maggi@gmail.com
